### PR TITLE
Workaround to override fontawesome default namespace

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ minima:
       url: "https://www.facebook.com/mtgbaselland/"
       title: "Unsere Facebook-Gruppe"
     - icon: calendar
+      fa_namespace: regular
       url: "/events.ics"
       title: "Event-Kalender"
 

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,0 +1,13 @@
+<ul class="social-media-list">
+    {%- for entry in site.minima.social_links -%}
+    {%- assign fa_namespace = entry.fa_namespace -%}
+    {%- unless entry.fa_namespace -%}
+    {%- assign fa_namespace = "brands" -%}
+    {%- endunless -%}
+    <li>
+        <a rel="me" href="{{ entry.url }}" target="_blank" title="{{ entry.title }}">
+            <span class="grey fa-{{ fa_namespace }} fa-{{ entry.icon }} fa-lg"></span>
+        </a>
+    </li>
+    {%- endfor -%}
+</ul>


### PR DESCRIPTION
Workaround for changes in minima theme regarding social links.

See: https://github.com/jekyll/minima/issues/843