### PR TITLE
Add deck link to 2025-12-05 draft event

### DIFF
--- a/_events/2025-12-05-draft.markdown
+++ b/_events/2025-12-05-draft.markdown
@@ -4,6 +4,7 @@ date: 2025-12-05 19:00:00
 title: "Avatar: The Last Airbender Draft / Duel Commander / Commander Party"
 location: Spielweltenfabrik
 winner: Doménique
+deck: https://moxfield.com/decks/BWIlSnliBkyUFMRVDyhzlA
 players:
   draft: 6
   commander: 6


### PR DESCRIPTION
Added deck link for the Avatar: The Last Airbender draft.